### PR TITLE
v4 1inch API

### DIFF
--- a/approve.go
+++ b/approve.go
@@ -10,7 +10,7 @@ import (
 // infinity will overwrite amount
 // amount is set in minimal divisible units: for example, to unlock 1 DAI, amount should be 1000000000000000000, to unlock 1.03 USDC, amount should be 1030000.
 func (c *Client) ApproveCalldata(ctx context.Context, network, tokenAddress string, opts *ApproveCalldataOpts) (*ApproveCalldataRes, int, error) {
-	endpoint := "/approve/calldata"
+	endpoint := "/approve/transaction"
 	if tokenAddress == "" {
 		return nil, 0, errors.New("required parameter is missing")
 	}

--- a/approve.go
+++ b/approve.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 )
 
-// ApproveCalldata gets calldata for approve transaction and spender address
+// ApproveTransaction gets calldata for approve transaction and spender address
 // Do not combine amount parameter with infinity parameter, only one must be sent.
 // infinity will overwrite amount
 // amount is set in minimal divisible units: for example, to unlock 1 DAI, amount should be 1000000000000000000, to unlock 1.03 USDC, amount should be 1030000.
-func (c *Client) ApproveCalldata(ctx context.Context, network, tokenAddress string, opts *ApproveCalldataOpts) (*ApproveCalldataRes, int, error) {
+func (c *Client) ApproveTransaction(ctx context.Context, network, tokenAddress string, opts *ApproveTransactionOpts) (*ApproveTransactionRes, int, error) {
 	endpoint := "/approve/transaction"
 	if tokenAddress == "" {
 		return nil, 0, errors.New("required parameter is missing")
@@ -25,7 +25,7 @@ func (c *Client) ApproveCalldata(ctx context.Context, network, tokenAddress stri
 		}
 	}
 
-	var dataRes ApproveCalldataRes
+	var dataRes ApproveTransactionRes
 	statusCode, err := c.doRequest(ctx, network, endpoint, "GET", &dataRes, nil, queries)
 	if err != nil {
 		return nil, statusCode, err

--- a/approve.go
+++ b/approve.go
@@ -43,3 +43,22 @@ func (c *Client) ApproveSpender(ctx context.Context, network string) (*ApproveSp
 	}
 	return &dataRes, statusCode, nil
 }
+
+// ApproveAllowance gets the number of tokens that the 1inch router is allowed to spend
+func (c *Client) ApproveAllowance(ctx context.Context, network, tokenAddress, walletAddress string) (*ApproveAllowanceRes, int, error) {
+	endpoint := "/approve/allowance"
+	if tokenAddress == "" || walletAddress == "" {
+		return nil, 0, errors.New("required parameter is missing")
+	}
+
+	var queries = make(map[string]interface{})
+
+	queries["tokenAddress"] = tokenAddress
+	queries["walletAddress"] = walletAddress
+	var dataRes ApproveAllowanceRes
+	statusCode, err := c.doRequest(ctx, network, endpoint, "GET", &dataRes, nil, queries)
+	if err != nil {
+		return nil, statusCode, err
+	}
+	return &dataRes, statusCode, nil
+}

--- a/client.go
+++ b/client.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	inchURL = "https://api.1inch.exchange/v3.0/"
+	inchURL = "https://api.1inch.exchange/v4.0/"
 )
 
 var (

--- a/client.go
+++ b/client.go
@@ -16,9 +16,11 @@ const (
 
 var (
 	network = map[string]string{
-		"eth":   "1",
-		"bsc":   "56",
-		"matic": "137",
+		"eth":      "1",
+		"bsc":      "56",
+		"matic":    "137",
+		"optimism": "10",
+		"arbitrum": "42161",
 	}
 )
 

--- a/go1inch_test.go
+++ b/go1inch_test.go
@@ -164,9 +164,9 @@ func TestApproveSpender(t *testing.T) {
 	t.Log(res)
 }
 
-func TestApproveCalldataWithoutOpts(t *testing.T) {
+func TestApproveTransactionWithoutOpts(t *testing.T) {
 	client := go1inch.NewClient()
-	res, _, err := client.ApproveCalldata(
+	res, _, err := client.ApproveTransaction(
 		context.Background(),
 		"eth",
 		"0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -178,13 +178,13 @@ func TestApproveCalldataWithoutOpts(t *testing.T) {
 	t.Log(res)
 }
 
-func TestApproveCalldataWithOpts(t *testing.T) {
+func TestApproveTransactionWithOpts(t *testing.T) {
 	client := go1inch.NewClient()
-	res, _, err := client.ApproveCalldata(
+	res, _, err := client.ApproveTransaction(
 		context.Background(),
 		"eth",
 		"0x6b175474e89094c44da98b954eedeac495271d0f",
-		&go1inch.ApproveCalldataOpts{
+		&go1inch.ApproveTransactionOpts{
 			Amount: "100000",
 		},
 	)

--- a/go1inch_test.go
+++ b/go1inch_test.go
@@ -9,14 +9,17 @@ import (
 
 func TestHealthCheckReponse(t *testing.T) {
 	client := go1inch.NewClient()
-	res, _, err := client.Healthcheck(context.Background(), "eth")
-	if err != nil {
-		t.Error(err)
+	networks := []string{"eth", "bsc", "matic", "optimism", "arbitrum"}
+	for _, network := range networks {
+		res, _, err := client.Healthcheck(context.Background(), network)
+		if err != nil {
+			t.Error(err)
+		}
+		if res.Status != "OK" {
+			t.Errorf("healthcheck returned %s, expected OK", res.Status)
+		}
+		t.Logf("Network healthcheck %s: %v", network, res)
 	}
-	if res.Status != "OK" {
-		t.Errorf("healthcheck returned %s, expected OK", res.Status)
-	}
-	t.Log(res)
 }
 
 func TestQuoteWithoutOpts(t *testing.T) {
@@ -132,10 +135,10 @@ func TestSwapWithMissingParameter(t *testing.T) {
 	}
 }
 
-func TestGetProtocols(t *testing.T) {
+func TestGetLiquiditySouces(t *testing.T) {
 	client := go1inch.NewClient()
 
-	res, _, err := client.Protocols(context.Background(), "matic")
+	res, _, err := client.LiquiditySouces(context.Background(), "matic")
 	if err != nil {
 		t.Error(err)
 	}

--- a/go1inch_test.go
+++ b/go1inch_test.go
@@ -164,6 +164,17 @@ func TestApproveSpender(t *testing.T) {
 	t.Log(res)
 }
 
+// func TestApproveAllowance(t *testing.T) {
+// 	const TOKEN_ADDRESS = "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c" //WBNB
+// 	const WALLET_ADDRESS = ""                                          // Wallet that has Router V4 approved for WBNB
+// 	client := go1inch.NewClient()
+// 	res, _, err := client.ApproveAllowance(context.Background(), "bsc", TOKEN_ADDRESS, WALLET_ADDRESS)
+// 	if err != nil {
+// 		t.Error(err)
+// 	}
+// 	t.Log(res)
+// }
+
 func TestApproveTransactionWithoutOpts(t *testing.T) {
 	client := go1inch.NewClient()
 	res, _, err := client.ApproveTransaction(

--- a/go1inch_test.go
+++ b/go1inch_test.go
@@ -142,16 +142,6 @@ func TestGetProtocols(t *testing.T) {
 	t.Log(res)
 }
 
-func TestGetProtocolsImages(t *testing.T) {
-	client := go1inch.NewClient()
-
-	res, _, err := client.ProtocolsImages(context.Background(), "bsc")
-	if err != nil {
-		t.Error(err)
-	}
-	t.Log(res)
-}
-
 func TestGetTokens(t *testing.T) {
 	client := go1inch.NewClient()
 

--- a/go1inch_types.go
+++ b/go1inch_types.go
@@ -10,7 +10,7 @@ type HealthcheckRes struct {
 	Status string `json:"status"`
 }
 
-type ApproveCalldataOpts struct {
+type ApproveTransactionOpts struct {
 	// Amount of tokens to be approved:
 	// 0 — set approval to zero (lock a token)
 	// >0 — approve exact amount of tokens.
@@ -18,7 +18,7 @@ type ApproveCalldataOpts struct {
 	Amount string
 }
 
-type ApproveCalldataRes struct {
+type ApproveTransactionRes struct {
 	// token contract address
 	To string `json:"to"`
 	// amount of eth to be sent (in wei)

--- a/go1inch_types.go
+++ b/go1inch_types.go
@@ -161,11 +161,6 @@ type SwapRes struct {
 	Tx Tx `json:"tx"`
 }
 
-type ProtocolsRes struct {
-	// protocol names
-	Protocols []string `json:"protocols"`
-}
-
 type ProtocolsImages struct {
 	Id    string `json:"id"`
 	Title string `json:"title"`

--- a/go1inch_types.go
+++ b/go1inch_types.go
@@ -34,6 +34,11 @@ type ApproveSpenderRes struct {
 	Address string `json:"address"`
 }
 
+type ApproveAllowanceRes struct {
+	// address of 1inch contract
+	Allowance string `json:"allowance"`
+}
+
 type QuoteOpts struct {
 	// referrer's fee in percentage
 	// Ethereum: min: 0; max: 3; Binance: min: 0; max: 3; default: 0; !should be the same for quote and swap!

--- a/go1inch_types.go
+++ b/go1inch_types.go
@@ -161,14 +161,14 @@ type SwapRes struct {
 	Tx Tx `json:"tx"`
 }
 
-type ProtocolsImages struct {
+type Protocols struct {
 	Id    string `json:"id"`
 	Title string `json:"title"`
 	Img   string `json:"img"`
 }
 
-type ProtocolsImagesRes struct {
-	Protocols []ProtocolsImages `json:"protocols"`
+type LiquiditySoucesRes struct {
+	Protocols []Protocols `json:"protocols"`
 }
 
 type TokensRes struct {

--- a/protocols.go
+++ b/protocols.go
@@ -4,20 +4,9 @@ import (
 	"context"
 )
 
-// Protocols gets array of all supported liquidity protocols
-func (c *Client) Protocols(ctx context.Context, network string) (*ProtocolsRes, int, error) {
-	endpoint := "/protocols"
-	var dataRes ProtocolsRes
-	statusCode, err := c.doRequest(ctx, network, endpoint, "GET", &dataRes, nil)
-	if err != nil {
-		return nil, statusCode, err
-	}
-	return &dataRes, statusCode, nil
-}
-
 // ProtocolsImages gets names and images of all supported protocols
-func (c *Client) ProtocolsImages(ctx context.Context, network string) (*ProtocolsImagesRes, int, error) {
-	endpoint := "/protocols/images"
+func (c *Client) Protocols(ctx context.Context, network string) (*ProtocolsImagesRes, int, error) {
+	endpoint := "/liquidity-sources"
 	var dataRes ProtocolsImagesRes
 	statusCode, err := c.doRequest(ctx, network, endpoint, "GET", &dataRes, nil)
 	if err != nil {

--- a/protocols.go
+++ b/protocols.go
@@ -5,9 +5,9 @@ import (
 )
 
 // ProtocolsImages gets names and images of all supported protocols
-func (c *Client) Protocols(ctx context.Context, network string) (*ProtocolsImagesRes, int, error) {
+func (c *Client) LiquiditySouces(ctx context.Context, network string) (*LiquiditySoucesRes, int, error) {
 	endpoint := "/liquidity-sources"
-	var dataRes ProtocolsImagesRes
+	var dataRes LiquiditySoucesRes
 	statusCode, err := c.doRequest(ctx, network, endpoint, "GET", &dataRes, nil)
 	if err != nil {
 		return nil, statusCode, err


### PR DESCRIPTION
1inch made v4 api available that uses the Router v4. 
This PR is just a quick fix to make the tests work with the new API. I've notice 2 breaking changes:
- `/approve/calldata` -> `/approve/transaction`
- `/protocols` is gone, is now `/liquidity-sources` which seems to be the same thing as protocol-images in v3.

I'm not sure how backwards compatible this library wants to be, or just want to implement the breaking changes. (And maybe rename the types according to the new name for liquidity sources)